### PR TITLE
Feature: support makeshift in a Mingw64 environment (MSYS)

### DIFF
--- a/make/os/Makefile
+++ b/make/os/Makefile
@@ -1,8 +1,8 @@
 #
 # Makefile --Build rules for the os directory of devkit.
 #
-MK_SRC = Windows_NT.mk cygwin_nt.mk darwin.mk freebsd.mk linux.mk \
-    posix.mk rtx.mk solaris.mk unknown.mk
+MK_SRC = cygwin_nt.mk darwin.mk freebsd.mk linux.mk mingw64_nt.mk \
+    posix.mk rtx.mk solaris.mk unknown.mk Windows_NT.mk
 subdir	= os
 
 include devkit.mk

--- a/make/os/mingw64_nt.mk
+++ b/make/os/mingw64_nt.mk
@@ -1,0 +1,19 @@
+#
+# MINGW64_NT.MK	--Definitions for Windows using the mingw64 environment.
+#
+# Remarks:
+# For builds on windows, OS is pre-set to "Windows_NT".  However,
+# uname(1) outputs "mingw64_NT" for the system name, this file allows
+# it to be used as an alternative.
+#
+include os/posix.mk
+
+OS.CFLAGS 	= -MMD
+OS.C_DEFS	= -D__Mingw64_NT__  -D_XOPEN_SOURCE -D_BSD_SOURCE
+
+OS.CXXFLAGS 	= -MMD
+OS.C++_DEFS	= -D__Mingw64_NT__   -D_XOPEN_SOURCE -D_BSD_SOURCE
+
+
+DESTDIR		= /
+


### PR DESCRIPTION
Use case: use makeshift in a MSYS environment (i.e. mingw64).
Original Problem: uname in msys outputs mingw64_NT as system name, for which makeshift does not have an os/mingw64_nt.mk file. This resolves the problem; contents are very similar to cygwin_nt.mk or Windows_NT.mk

This feature should not cause any problems for existing functionality. 