### PR TITLE
Feature: make archdir and gendir configurable

### DIFF
--- a/make/std-directories.mk
+++ b/make/std-directories.mk
@@ -28,8 +28,11 @@ system_root	= $(DESTDIR)
 system_confdir	= $(abspath $(system_root)/etc/$(subdir))
 export pkgver	= $(PACKAGE)$(VERSION:%=-%)
 
-export archdir	= $(VARIANT:%=%-)$(OS:%=%-)$(ARCH)
-export gendir	= $(archdir)/gen
+archdir         ?= $(VARIANT:%=%-)$(OS:%=%-)$(ARCH)
+export archdir
+gendir	?= $(archdir)/gen
+export gendir
+
 rootdir	 	= $(abspath $(DESTDIR)/$(prefix))
 optdir	 	= $(opt:%=opt/%)
 rootdir_opt 	= $(abspath $(DESTDIR)/$(prefix)/$(optdir))


### PR DESCRIPTION
Usecase: there are situations where the standard variant-os-arch naming for archdir and the default $archdir/gen naming for gendir are not exactly what is needed. For example, I build a C# project where I want to mimic Visual Studio naming conventions; another project I have is a documentation only project where I only compile .md into .pdf and I'd rather have a different name altogether for the directory where the build artefacts go.

This very small change allows archdir and gendir  to be set in for example the project specific .mk file.