### PR TITLE
Feature/read the docs integration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Configuration to setup auto building in Read the Docs.
+#
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: "ubuntu-24.04"
+  tools:
+    python: "3.11"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/api-reference/language-c.md
+++ b/docs/api-reference/language-c.md
@@ -1,0 +1,3 @@
+# C Language API Reference
+
+TODO

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started with Makeshift
+
+TODO

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Makeshift
+
+TODO

--- a/docs/javascript/readthedocs.js
+++ b/docs/javascript/readthedocs.js
@@ -1,0 +1,45 @@
+// Document Integration for Read the Docs hosting.
+//
+// Obtained from https://docs.readthedocs.com/platform/stable/intro/mkdocs.html
+
+document.addEventListener("DOMContentLoaded", function(event) {
+// Trigger Read the Docs' search addon instead of Material MkDocs default
+document.querySelector(".md-search__input").addEventListener(
+    "focus", (e) => {
+        const event = new CustomEvent("readthedocs-search-show");
+        document.dispatchEvent(event);
+    });
+});
+
+// Use CustomEvent to generate the version selector
+document.addEventListener(
+    "readthedocs-addons-data-ready",
+    function (event) {
+    const config = event.detail.data();
+    const versioning = `
+<div class="md-version">
+<button class="md-version__current" aria-label="Select version">
+    ${config.versions.current.slug}
+</button>
+
+<ul class="md-version__list">
+${ config.versions.active.map(
+    (version) => `
+    <li class="md-version__item">
+    <a href="${ version.urls.documentation }" class="md-version__link">
+        ${ version.slug }
+    </a>
+            </li>`).join("\n")}
+</ul>
+</div>`;
+
+    // Check if we already added versions and remove them if so.
+    // This happens when using the "Instant loading" feature.
+    // See https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#instant-loading
+    const currentVersions = document.querySelector(".md-version");
+    if (currentVersions !== null) {
+      currentVersions.remove();
+    }
+    document.querySelector(".md-header__topic")
+        .insertAdjacentHTML("beforeend", versioning);
+});

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block site_meta %}
+{{ super() }}
+<meta name="readthedocs-addons-api-version" content="1" />
+{% endblock %}

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,10 @@
+# Requirements for the documentation
+#
+# These are matched to the versions found on Ubuntu so you can install into system
+# Python if you prefer.
+# 
+# SPDX-FileCopyrightText: 2006-2023 Tim Rose <tim.rose@acm.org>
+# SPDX-License-Identifier: MIT
+
+mkdocs~=1.4.2
+mkdocs-material~=8.2.5

--- a/docs/tutorials/hello-world.md
+++ b/docs/tutorials/hello-world.md
@@ -1,0 +1,3 @@
+# Your First Makeshift Project
+
+TODO

--- a/docs/user-manual/language-c.md
+++ b/docs/user-manual/language-c.md
@@ -1,0 +1,3 @@
+# C Language Support
+
+TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: Makeshift
+docs_dir: docs
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Tutorials:
+    - Hello World: tutorials/hello-world.md
+  - User Manual:
+    - Language Support:
+      - C: user-manual/language-c.md
+  - API Reference:
+    - Language Support:
+      - C: api-reference/language-c.md
+theme:
+  name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,8 @@ nav:
       - C: api-reference/language-c.md
 theme:
   name: material
+  # Used for Read the Docs hosting support
+  custom_dir: docs/overrides
+extra_javascript:
+  # Used for Read the Docs hosting support
+  - javascript/readthedocs.js


### PR DESCRIPTION
Adds basic infrastructure for online documentation.

I decided to go with `mkdocs` instead of `sphinx` as `mkdocs` is simpler to use. I don't think we need the complexity of Sphinx yet.